### PR TITLE
Patch duckdb to avoid optimizing with wasm-opt

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -23,7 +23,7 @@ jobs:
 
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.3.1
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       duckdb_version: v1.3.1
       ci_tools_version: v1.3.1

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
 # Include the Makefile from extension-ci-tools
 include extension-ci-tools/makefiles/duckdb_extension.Makefile
+
+# Override WASM targets: THIS IS AN HACK, needs fixing in DuckDB to allow passing optimization level and other options, but still allows this to be build as out of tree extension
+wasm_pre_build_step:
+	cd duckdb && git apply --3way ../cmakelists.patch && cd ..

--- a/cmakelists.patch
+++ b/cmakelists.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index eecaf5130c..7d4632e392 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -959,7 +959,7 @@ function(build_loadable_extension_directory NAME ABI_TYPE OUTPUT_DIRECTORY EXTEN
+     add_custom_command(
+       TARGET ${TARGET_NAME}
+       POST_BUILD
+-      COMMAND emcc $<TARGET_FILE:${TARGET_NAME}> -o $<TARGET_FILE:${TARGET_NAME}>.wasm -O3 -sSIDE_MODULE=2 -sEXPORTED_FUNCTIONS="${EXPORTED_FUNCTIONS}" ${WASM_THREAD_FLAGS} ${TO_BE_LINKED}
++      COMMAND emcc $<TARGET_FILE:${TARGET_NAME}> -o $<TARGET_FILE:${TARGET_NAME}>.wasm -O1 -sSIDE_MODULE=2 -sEXPORTED_FUNCTIONS="${EXPORTED_FUNCTIONS}" ${WASM_THREAD_FLAGS} ${TO_BE_LINKED}
+       )
+   endif()
+ 


### PR DESCRIPTION
This is a proper HACK, so beware.

This can be merged for the purpose of having encoding built for 1.3.1 / upcoming 1.3.2, but needs to be reverted.

Problem is as follow:
* encodings generates a lot of code, that somehow trips `wasm-opt` (invoked by `emcc`) in what could either be a more than linear optimization or possibly an infinite loop when optimized with all optimization enabled (`-O3`)
* proper solution is allowing WASM_OPT options to be overridden from an extension, but that requires changing duckdb
* hack: just patching a single line of CMakeLists, the one that dictate the optimization level, and moving it from `-O3` to `-O1`.

I think this is horrible but I would say OK, on the count that this touches only on Wasm compilaton, and allows the library to be available.

I will send a PR to duckdb/duckdb main branch that allow to remove this hack, but I think it's cute to have this also in duckdb-wasm.

I can also see reasons NOT to merge this, that's also fine, if so it should be a matter of adding lines like:
```
      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
```
at the bottom of both steps, see for example https://github.com/duckdb/duckdb-postgres/blob/main/.github/workflows/MainDistributionPipeline.yml