### PR TITLE
Fix: Only use exact roundtrip mappings from UCM files, skip fallback mappings

### DIFF
--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -71,8 +71,14 @@ def parse_ucm_to_utf8_map(ucm_path):
 			if not in_charmap:
 				continue
 
-			match = re.match(r'<U([0-9A-Fa-f]+)>\s+((?:\\x[0-9A-Fa-f]{2})+)\s+\|\d+', line)
+			match = re.match(r'<U([0-9A-Fa-f]+)>\s+((?:\\x[0-9A-Fa-f]{2})+)\s+\|(\d+)', line)
 			if not match:
+				continue
+
+			# Only process exact roundtrip mappings (fallback indicator = 0)
+			# Skip fallback mappings (|1, |2, |3) to avoid overwriting correct mappings with fullwidth/fallback characters
+			fallback_indicator = int(match.group(3))
+			if fallback_indicator != 0:
 				continue
 
 			unicode_scalar = int(match.group(1), 16)


### PR DESCRIPTION
This fixes a critical bug where ASCII characters (`0x21-0x7E`) were incorrectly converted to fullwidth Unicode equivalents when reading files with various encodings, particularly `Windows-1251`.

### Problem issued
https://github.com/duckdb/duckdb/issues/19267

### Affected by the bug
- CSV parsing failures (delimiters not recognized)
- Multiple columns merged into one
- Numbers, commas, semicolons displayed as fullwidth (`１，；`  instead of `1,;`)

### Root cause
The converter script was processing ALL mappings from UCM files, including fallback mappings (`|1`, `|2`, `|3`). Since dictionaries store only one value per key, fallback mappings overwrote exact mappings (`|0`), resulting in incorrect character conversions.

### Example
```
  <U0021> \x21 |0  # Correct: EXCLAMATION MARK
  <UFF01> \x21 |1  # Fallback: FULLWIDTH EXCLAMATION MARK (was winning)
```

### Solution
Modified scripts/converter.py to only process exact roundtrip mappings (`|0`), ignoring all fallback mappings (`|1, |2, |3`).
Fixes [19267](https://github.com/duckdb/duckdb/issues/19267).